### PR TITLE
Drupal 8 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "illuminate/container": "~5.5.0|~5.6.0",
     "illuminate/config": "~5.5.0|~5.6.0",
     "illuminate/filesystem": "~5.5.0|~5.6.0",
-    "symfony/http-kernel": "~3.0.0|~4.0.0"
+    "symfony/http-kernel": "~3|~4"
   },
   "require-dev": {
     "phpunit/phpunit": "~6.0.0|~7.0.0"


### PR DESCRIPTION
I was unable to use this package with Drupal 8. It looked like the symfony/http-kernel should not need the ".0.0". Getting rid of that, made it install.

But I'm not a composer.json expert!