### PR TITLE
Clarify trailing slash does not work

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ $rules = new RequestLimitRuleset([
     ]);
 ```
 
+Make sure the host name does not end with a trailing slash. It should
+be `https://www.google.com` not `https://www.google.com/`.
 
 ----------
 


### PR DESCRIPTION
Initially I used https://www.google.com/ instead of https://www.google.com, but that doesn't work, so made that explicit in the documentation.