### PR TITLE
Feature/custom storage stratage usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,30 @@ You need to provide a config (`Illuminate\Config\Repository`) for this adapter.
 
 ----------
 
+##### Custom (Implements `hamburgscleanest\GuzzleAdvancedThrottle\Cache\Interfaces\StorageInterface`)
+
+> Available in version 2.0.5 and higher
+
+When you create a new implementation, pass the class name to the `RequestLimitRuleset::create` method. 
+You'll also need to implement any sort of configuration parsing your instance needs.
+Please see `LarvalAdapter` for an example.
+
+###### Usage:
+``` php
+$rules = new RequestLimitRuleset(
+    [ ... ], 
+    'force-cache', // caching strategy
+    MyCustomAdapter::class // storage adapter
+    );
+    
+$throttle = new ThrottleMiddleware($rules);
+
+// Invoke the middleware
+$stack->push($throttle());  
+```
+
+----------
+
 #### Laravel Drivers
 
 ##### File
@@ -249,6 +273,30 @@ $rules = new RequestLimitRuleset(
     'array' // storage adapter
     );
 ```
+
+----------
+
+#### Custom caching strategy
+
+> Available in version 2.0.5 and higher
+
+Your custom caching strategy must implement `CacheStrategy`.
+It is suggested you use `Cachable` (not there's no 'e') for a parent class.
+This will give a good head start, see `ForceCache` and `Cache` for ideas.
+
+To use your custom caching strategy, you'll need to pass the fully qualified cache name to `RequestLimitRuleset`.
+
+##### Usage
+```php
+$rules = new RequestLimitRuleset([ ... ], 
+                                MyCustomCacheStrategy::class, 
+                                'array', 
+                                new Repository(...));
+                                
+$throttle = new ThrottleMiddleware($rules);
+...                                
+```
+
 
 ----------
 

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ $rules = new RequestLimitRuleset(
 > Available in version 2.0.5 and higher
 
 Your custom caching strategy must implement `CacheStrategy`.
-It is suggested you use `Cachable` (not there's no 'e') for a parent class.
+It is suggested you use `Cacheable` for a parent class.
 This will give a good head start, see `ForceCache` and `Cache` for ideas.
 
 To use your custom caching strategy, you'll need to pass the fully qualified cache name to `RequestLimitRuleset`.

--- a/src/Cache/Strategies/Cache.php
+++ b/src/Cache/Strategies/Cache.php
@@ -11,7 +11,7 @@ use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
  * Class Cache
  * @package hamburgscleanest\GuzzleAdvancedThrottle\Cache\Strategies
  */
-class Cache extends Cachable
+class Cache extends Cacheable
 {
 
     /**

--- a/src/Cache/Strategies/Cacheable.php
+++ b/src/Cache/Strategies/Cacheable.php
@@ -13,7 +13,7 @@ use Psr\Http\Message\ResponseInterface;
  * Class Cache
  * @package hamburgscleanest\GuzzleAdvancedThrottle\Cache\Strategies
  */
-class Cachable implements CacheStrategy
+class Cacheable implements CacheStrategy
 {
 
     /** @var StorageInterface */

--- a/src/Cache/Strategies/ForceCache.php
+++ b/src/Cache/Strategies/ForceCache.php
@@ -10,7 +10,7 @@ use Psr\Http\Message\RequestInterface;
  * Class ForceCache
  * @package hamburgscleanest\GuzzleAdvancedThrottle\Cache\Strategies
  */
-class ForceCache extends Cachable
+class ForceCache extends Cacheable
 {
 
     /**

--- a/src/RequestLimitRuleset.php
+++ b/src/RequestLimitRuleset.php
@@ -66,6 +66,7 @@ class RequestLimitRuleset
     }
 
     /**
+     * Sets internal storage adapter for this rule set.
      * @param string $adapterName
      * @throws \hamburgscleanest\GuzzleAdvancedThrottle\Exceptions\UnknownStorageAdapterException
      */
@@ -94,6 +95,7 @@ class RequestLimitRuleset
     }
 
     /**
+     * Sets the caching strategy for this rule set.
      * @param string $cacheStrategy
      * @throws \hamburgscleanest\GuzzleAdvancedThrottle\Exceptions\UnknownCacheStrategyException
      */

--- a/src/RequestLimitRuleset.php
+++ b/src/RequestLimitRuleset.php
@@ -82,18 +82,12 @@ class RequestLimitRuleset
 
         if (!$this->_implementsInterface(StorageInterface::class, $adapterClassName))
         {
-            // Make sure we have the default classes in the array for the exception
-            // This is an ugly way to do this...
-            foreach (self::STORAGE_MAP as $key => $klass)
-            {
-                \class_exists($klass);
-            }
-
             $validStrategies = \array_filter(get_declared_classes(), function($className) {
                     return $this->_implementsInterface(StorageInterface::class, $className);
                 }
             );
-            throw new UnknownStorageAdapterException($adapterClassName, $validStrategies);
+            throw new UnknownStorageAdapterException($adapterClassName,
+                $validStrategies + \array_values(self::STORAGE_MAP));
         }
 
         $this->_storage = new $adapterClassName($this->_config);
@@ -116,17 +110,12 @@ class RequestLimitRuleset
 
         if (!$this->_implementsInterface(CacheStrategy::class, $cacheStrategyClassName))
         {
-            // Make sure we have the default classes in the array for the exception
-            // This is an ugly way to do this...
-            foreach (self::CACHE_STRATEGIES as $key => $klass)
-            {
-                \class_exists($klass);
-            }
-
             $validStrategies = \array_filter(get_declared_classes(), function($className) {
                 return $this->_implementsInterface(CacheStrategy::class, $className);
             });
-            throw new UnknownCacheStrategyException($cacheStrategyClassName, $validStrategies);
+
+            throw new UnknownCacheStrategyException($cacheStrategyClassName,
+                $validStrategies + \array_values(self::CACHE_STRATEGIES));
         }
 
         $this->_cacheStrategy = new $cacheStrategyClassName($this->_storage);

--- a/src/RequestLimitRuleset.php
+++ b/src/RequestLimitRuleset.php
@@ -89,7 +89,7 @@ class RequestLimitRuleset
                 class_exists($klass);
             }
 
-            $validStrategies = array_filter(get_declared_classes(), function ($className) {
+            $validStrategies = array_filter(get_declared_classes(), function($className) {
                     return in_array(StorageInterface::class, class_implements($className));
                 }
             );
@@ -123,7 +123,7 @@ class RequestLimitRuleset
                 class_exists($klass);
             }
 
-            $validStrategies = array_filter(get_declared_classes(), function ($className) {
+            $validStrategies = array_filter(get_declared_classes(), function($className) {
                 return in_array(CacheStrategy::class, class_implements($className));
             });
             throw new UnknownCacheStrategyException($cacheStrategyClassName, $validStrategies);

--- a/src/RequestLimitRuleset.php
+++ b/src/RequestLimitRuleset.php
@@ -81,10 +81,10 @@ class RequestLimitRuleset
             $adapterClassName = self::STORAGE_MAP[$adapterName];
         }
 
-        if (!$this->_implementsInterface(StorageInterface::class, $adapterClassName))
+        if (!$this->_implementsInterface($adapterClassName, StorageInterface::class))
         {
             $validStrategies = \array_filter(get_declared_classes(), function($className) {
-                    return $this->_implementsInterface(StorageInterface::class, $className);
+                    return $this->_implementsInterface($className, StorageInterface::class);
                 }
             );
             throw new UnknownStorageAdapterException($adapterClassName,
@@ -110,10 +110,10 @@ class RequestLimitRuleset
             $cacheStrategyClassName = self::CACHE_STRATEGIES[$cacheStrategy];
         }
 
-        if (!$this->_implementsInterface(CacheStrategy::class, $cacheStrategyClassName))
+        if (!$this->_implementsInterface($cacheStrategyClassName, CacheStrategy::class))
         {
             $validStrategies = \array_filter(get_declared_classes(), function($className) {
-                return $this->_implementsInterface(CacheStrategy::class, $className);
+                return $this->_implementsInterface($className, CacheStrategy::class);
             });
 
             throw new UnknownCacheStrategyException($cacheStrategyClassName,

--- a/src/RequestLimitRuleset.php
+++ b/src/RequestLimitRuleset.php
@@ -80,17 +80,17 @@ class RequestLimitRuleset
             $adapterClassName = self::STORAGE_MAP[$adapterName];
         }
 
-        if (!in_array(StorageInterface::class, class_implements($adapterClassName)))
+        if (!$this->_implementsInterface(StorageInterface::class, $adapterClassName))
         {
             // Make sure we have the default classes in the array for the exception
             // This is an ugly way to do this...
             foreach (self::STORAGE_MAP as $key => $klass)
             {
-                class_exists($klass);
+                \class_exists($klass);
             }
 
-            $validStrategies = array_filter(get_declared_classes(), function($className) {
-                    return in_array(StorageInterface::class, class_implements($className));
+            $validStrategies = \array_filter(get_declared_classes(), function($className) {
+                    return $this->_implementsInterface(StorageInterface::class, $className);
                 }
             );
             throw new UnknownStorageAdapterException($adapterClassName, $validStrategies);
@@ -114,22 +114,32 @@ class RequestLimitRuleset
             $cacheStrategyClassName = self::CACHE_STRATEGIES[$cacheStrategy];
         }
 
-        if (!in_array(CacheStrategy::class, class_implements($cacheStrategyClassName)))
+        if (!$this->_implementsInterface(CacheStrategy::class, $cacheStrategyClassName))
         {
             // Make sure we have the default classes in the array for the exception
             // This is an ugly way to do this...
             foreach (self::CACHE_STRATEGIES as $key => $klass)
             {
-                class_exists($klass);
+                \class_exists($klass);
             }
 
-            $validStrategies = array_filter(get_declared_classes(), function($className) {
-                return in_array(CacheStrategy::class, class_implements($className));
+            $validStrategies = \array_filter(get_declared_classes(), function($className) {
+                return $this->_implementsInterface(CacheStrategy::class, $className);
             });
             throw new UnknownCacheStrategyException($cacheStrategyClassName, $validStrategies);
         }
 
         $this->_cacheStrategy = new $cacheStrategyClassName($this->_storage);
+    }
+
+    /**
+     * Returns true|false if the $implementerClassName implements interface $interfaceName
+     * @param string $implementerClassName class name of the implementation class to test
+     * @param string $interfaceName name of the interface that should be implemented
+     * @return bool TRUE if the $implementerClassName implements $interfaceName, FALSE otherwise
+     */
+    private function _implementsInterface(string $implementerClassName, string $interfaceName) : bool {
+        return \in_array($interfaceName, \class_implements($implementerClassName), TRUE);
     }
 
     /**

--- a/tests/DummyCacheStrategy.php
+++ b/tests/DummyCacheStrategy.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: jporter
+ * Date: 5/29/18
+ * Time: 7:50 PM
+ */
+
+namespace hamburgscleanest\GuzzleAdvancedThrottle\Tests;
+
+
+use GuzzleHttp\Promise\PromiseInterface;
+use hamburgscleanest\GuzzleAdvancedThrottle\Cache\Interfaces\CacheStrategy;
+use hamburgscleanest\GuzzleAdvancedThrottle\Cache\Interfaces\StorageInterface;
+use Psr\Http\Message\RequestInterface;
+
+class DummyCacheStrategy implements CacheStrategy
+{
+
+    /**
+     * CacheStrategy constructor.
+     * @param null|StorageInterface $storage
+     */
+    public function __construct(?StorageInterface $storage = null)
+    {
+    }
+
+    /**
+     * @param RequestInterface $request
+     * @param callable $handler
+     * @return PromiseInterface
+     */
+    public function request(RequestInterface $request, callable $handler): PromiseInterface
+    {
+        return $handler();
+    }
+}

--- a/tests/DummyStorageAdapter.php
+++ b/tests/DummyStorageAdapter.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: jporter
+ * Date: 5/29/18
+ * Time: 7:53 PM
+ */
+
+namespace hamburgscleanest\GuzzleAdvancedThrottle\Tests;
+
+
+use DateTime;
+use hamburgscleanest\GuzzleAdvancedThrottle\Cache\Interfaces\StorageInterface;
+use hamburgscleanest\GuzzleAdvancedThrottle\RequestInfo;
+use Illuminate\Config\Repository;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class DummyStorageAdapter implements StorageInterface
+{
+
+    /**
+     * StorageInterface constructor.
+     * @param Repository|null $config
+     */
+    public function __construct(?Repository $config = null)
+    {
+    }
+
+    /**
+     * @param string $host
+     * @param string $key
+     * @param int $requestCount
+     * @param DateTime $expiresAt
+     * @param int $remainingSeconds
+     */
+    public function save(string $host, string $key, int $requestCount, DateTime $expiresAt, int $remainingSeconds): void
+    {
+    }
+
+    /**
+     * @param string $host
+     * @param string $key
+     * @return RequestInfo|null
+     */
+    public function get(string $host, string $key): ?RequestInfo
+    {
+        return null;
+    }
+
+    /**
+     * @param RequestInterface $request
+     * @param ResponseInterface $response
+     */
+    public function saveResponse(RequestInterface $request, ResponseInterface $response): void
+    {
+        return null;
+    }
+
+    /**
+     * @param RequestInterface $request
+     * @return ResponseInterface|null
+     */
+    public function getResponse(RequestInterface $request): ?ResponseInterface
+    {
+        return null;
+    }
+}

--- a/tests/DummyStorageAdapter.php
+++ b/tests/DummyStorageAdapter.php
@@ -54,7 +54,6 @@ class DummyStorageAdapter implements StorageInterface
      */
     public function saveResponse(RequestInterface $request, ResponseInterface $response): void
     {
-        return null;
     }
 
     /**


### PR DESCRIPTION
I've implemented basic searching for interface implementations of the
caching strategies and adapters while keeping the same signature and
basic usage. There shouldn't be any breaking changes.

I believe the added tests should cover all the new paths in the code.

<!--- Provide a general summary of your changes in the Title above -->

## Description
I implemented the feature requested in #10 

## Motivation and context
See #10

## How has this been tested?

The current suite of tests still works, and I added some other tests to cover the new paths in the code.

## Screenshots (if appropriate)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [X] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [X] My pull request addresses exactly one patch/feature.
- [X] I have created a branch for this patch/feature.
- [X] Each individual commit in the pull request is meaningful.
- [X] I have added tests to cover my changes.
- [X] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!