### PR TITLE
Request empty throw error

### DIFF
--- a/src/Helpers/RequestHelper.php
+++ b/src/Helpers/RequestHelper.php
@@ -74,10 +74,9 @@ class RequestHelper
      */
     private static function _decodeJSON(string $json) : string
     {
-        try {
-            return http_build_query(\GuzzleHttp\json_decode($json, true), '', '&');
-        } catch (\Exception $e) {
-            return $json;
+        if(empty($json)) {
+            return ''; // or also like in your code just return $json
         }
+        return http_build_query(\GuzzleHttp\json_decode($json, true), '', '&');
     }
 }

--- a/src/Helpers/RequestHelper.php
+++ b/src/Helpers/RequestHelper.php
@@ -74,6 +74,10 @@ class RequestHelper
      */
     private static function _decodeJSON(string $json) : string
     {
-        return http_build_query(\GuzzleHttp\json_decode($json, true), '', '&');
+        try {
+            return http_build_query(\GuzzleHttp\json_decode($json, true), '', '&');
+        } catch (\Exception $e) {
+            return $json;
+        }
     }
 }


### PR DESCRIPTION
When empty request I get a exception

![captura de tela de 2018-10-03 10-24-26](https://user-images.githubusercontent.com/2566340/46413410-3bf60200-c6f7-11e8-9ac4-495b2e00ec3b.png)

I wrap in a try catch the json_decode in case of error return raw string
